### PR TITLE
Add http.response.record.skip.error (default is true)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>no.norsktipping</groupId>
     <artifactId>kafka-connect-http</artifactId>
     <name>Kafka Connect HTTP</name>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <scm>
         <developerConnection>scm:git:https://x-access-token:${env.GITHUB_TOKEN}@github.com/Norsk-Tipping/kafka-connect-http.git</developerConnection>

--- a/src/main/java/com/github/castorm/kafka/connect/http/response/KvHttpResponseParserConfig.java
+++ b/src/main/java/com/github/castorm/kafka/connect/http/response/KvHttpResponseParserConfig.java
@@ -9,9 +9,9 @@ package com.github.castorm.kafka.connect.http.response;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,26 +31,30 @@ import org.apache.kafka.common.config.ConfigDef;
 import java.util.Map;
 
 import static org.apache.kafka.common.config.ConfigDef.Importance.LOW;
-import static org.apache.kafka.common.config.ConfigDef.Type.CLASS;
+import static org.apache.kafka.common.config.ConfigDef.Type.*;
 
 @Getter
 public class KvHttpResponseParserConfig extends AbstractConfig {
 
     private static final String RECORD_PARSER_CLASS = "http.response.record.parser";
     private static final String RECORD_MAPPER_CLASS = "http.response.record.mapper";
+    private static final String RECORD_PARSER_SKIP_ERROR = "http.response.record.skip.error";
 
     private final KvRecordHttpResponseParser recordParser;
     private final KvSourceRecordMapper recordMapper;
+    private final boolean skipError;
 
     KvHttpResponseParserConfig(Map<String, ?> originals) {
         super(config(), originals);
         recordParser = getConfiguredInstance(RECORD_PARSER_CLASS, KvRecordHttpResponseParser.class);
         recordMapper = getConfiguredInstance(RECORD_MAPPER_CLASS, KvSourceRecordMapper.class);
+        skipError = getBoolean(RECORD_PARSER_SKIP_ERROR);
     }
 
     public static ConfigDef config() {
         return new ConfigDef()
                 .define(RECORD_PARSER_CLASS, CLASS, JacksonKvRecordHttpResponseParser.class, LOW, "Key-Value Record Parser class")
-                .define(RECORD_MAPPER_CLASS, CLASS, SchemedKvSourceRecordMapper.class, LOW, "Key-Value Record Factory class");
+                .define(RECORD_MAPPER_CLASS, CLASS, SchemedKvSourceRecordMapper.class, LOW, "Key-Value Record Factory class")
+                .define(RECORD_PARSER_SKIP_ERROR, BOOLEAN, true, LOW, "ignore error and continue polling");
     }
 }


### PR DESCRIPTION
new config http.response.record.skip.error, default is true. If it is true, ignore http failure and continue polling.